### PR TITLE
Make sure classNames exists before calling “indexOf” on it

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -42,7 +42,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
                              '    name = name.replace(".","/");\n' +
-                             '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
+                             '    if (Component.prototype.classNames && Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +
                              '    return Component.reopen({\n' +
@@ -53,7 +53,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
                              '    name = name.replace(".","/");\n' +
-                             '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
+                             '    if (Component.prototype.classNames && Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +
                              '    return Component.reopen({\n' +


### PR DESCRIPTION
`GlimmerComponent` prototype doesn’t have a `classNames` property, so we can ignore the whole `if`.
